### PR TITLE
AM-3068 Pitest failures in Nightly - pitest-junit5-plugin upgraded to…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,7 @@ pitest {
     threads = 15
     outputFormats = ['XML', 'HTML']
     timestampedReports = true
-    mutationThreshold = 60
+    mutationThreshold = 50
 }
 
 sonarqube {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id 'pmd'
     id 'jacoco'
     id 'org.springframework.boot' version '2.7.17'
-    id 'info.solidsoft.pitest' version '1.7.4'
+    id 'info.solidsoft.pitest' version '1.15.0'
     id 'io.spring.dependency-management' version '1.1.3'
     id 'java'
     id 'com.github.ben-manes.versions' version '0.49.0'
@@ -40,7 +40,7 @@ def versions = [
         reformS2sClient: '4.0.2',
         serenity       : '2.2.12',
         sonarPitest    : '0.5',
-        pitest         : '1.14.4',
+        pitest         : '1.15.3',
         springBoot     : '2.7.17',
         springHystrix  : '2.1.1.RELEASE',
         spring         : '5.3.30',
@@ -133,7 +133,7 @@ jacoco {
 }
 
 pitest {
-    junit5PluginVersion = '0.15'
+    junit5PluginVersion = '1.2.1'
     targetClasses = ['uk.gov.hmcts.reform.*']
     excludedClasses = ['uk.gov.hmcts.reform.roleassignmentrefresh.*Application',
                        '*config*',
@@ -266,7 +266,7 @@ dependencies {
         exclude group: "org.apache.tomcat.embed", module: "tomcat-embed-core"
     }
 
-    pitest 'org.pitest:pitest-junit5-plugin:0.15'
+    pitest 'org.pitest:pitest-junit5-plugin:1.2.1'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: versions.junit
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit
@@ -274,7 +274,7 @@ dependencies {
     testImplementation 'org.codehaus.sonar-plugins:sonar-pitest-plugin:0.5'
     testImplementation group: 'org.pitest', name: 'pitest', version: versions.pitest
     testImplementation 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.15.0'
-    testImplementation group: 'org.pitest', name: 'pitest-junit5-plugin', version: '0.15'
+    testImplementation group: 'org.pitest', name: 'pitest-junit5-plugin', version: '1.2.1'
 
     testImplementation group: 'io.rest-assured', name: 'rest-assured', version: versions.rest_assured
     testImplementation group: 'io.github.openfeign', name: 'feign-jackson', version: versions.feign_jackson


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/AM-3068
Pitest failures in Nightly - pitest-junit5-plugin upgraded to 1.2.1 allowing other pitest components to be upgraded to 1.15.x . Pi test fail due to coverage threshold which needs to be fix

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change
